### PR TITLE
CW n point crossover

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,10 @@
   * Module: `code_challenges/code_wars/hacked.py`
   * Tests: `tests/code_wars/test_hacked.py`
   * URL: [challenge url](https://www.codewars.com/kata/59f70440bee845599c000085/train/python)
+### N-Point Crossover (6kyu)
+  * Module: `code_challenges/code_wars/n_point_crossover.py`
+  * Tests: `tests/code_wars/test_n_point_crossover.py`
+  * URL: [challenge url](https://www.codewars.com/kata/57339a5226196a7f90001bcf/train/python)
 ## Advent Of Code
 ### Rucksack Reorganization:
   * Module: `code_challenges/advent_of_code/rucksack_reorganization.py`

--- a/code_challenges/code_wars/n_point_crossover.py
+++ b/code_challenges/code_wars/n_point_crossover.py
@@ -1,0 +1,24 @@
+def crossover(ns, xs, ys):
+    sections = sorted(set(ns))
+    xs_list = xs.copy()
+    ys_list = ys.copy()
+
+    if len(sections) == 0:
+        return xs, ys
+    elif len(sections) == 1:
+        for number in range(sections[0], len(xs)):
+            xs_list[number] = ys[number]
+            ys_list[number] = xs[number]
+    elif len(sections) == 2:
+        for number in range(sections[0], sections[1]):
+            xs_list[number] = ys[number]
+            ys_list[number] = xs[number]
+    else:
+        for number in range(sections[0], sections[1]):
+            xs_list[number] = ys[number]
+            ys_list[number] = xs[number]
+        for number in range(sections[2], len(xs)):
+            xs_list[number] = ys[number]
+            ys_list[number] = xs[number]
+
+    return xs_list, ys_list

--- a/tests/code_wars/test_n_point_crossover.py
+++ b/tests/code_wars/test_n_point_crossover.py
@@ -1,0 +1,30 @@
+from code_challenges.code_wars.n_point_crossover import crossover
+
+
+def test_crossover_0():
+    actual = crossover([], [1, 2, 3], [4, 5, 6])
+    expected = [1, 2, 3], [4, 5, 6]
+    assert actual == expected, f"Returned {actual} instead of {expected}"
+
+
+def test_crossover_1():
+    actual = crossover([1], ["a", "b", "c"], ["x", "y", "z"])
+    expected = ["a", "y", "z"], ["x", "b", "c"]
+
+    assert actual == expected, f"Returned {actual} instead of {expected}"
+
+
+def test_crossover_2():
+    actual = crossover([1, 3], [1, 1, 1, 1, 1], [2, 2, 2, 2, 2])
+    expected = [1, 2, 2, 1, 1], [2, 1, 1, 2, 2]
+
+    assert actual == expected, f"Returned {actual} instead of {expected}"
+
+
+def test_crossover_3():
+    actual = crossover(
+        [1, 3, 5], ["a", "b", "c", "d", "e", "f", "g"], [1, 1, 1, 1, 1, 1, 1]
+    )
+    expected = ["a", 1, 1, "d", "e", 1, 1], [1, "b", "c", 1, 1, "f", "g"]
+
+    assert actual == expected, f"Returned {actual} instead of {expected}"


### PR DESCRIPTION
doesnt pass all of the codewars test but i think it is a mistake on their part
ns = [1, 3]
xs = [1, 1, 1, 1, 1]
ys = [1, 1, 1, 1, 1]
(the inputs)
the fail message : ([1, 1, 1, 1, 1], [1, 1, 1, 1, 1]) should equal ([1, 2, 2, 1, 1], [2, 1, 1, 2, 2])